### PR TITLE
Adjust the description of out-of-bounds array access consequences.

### DIFF
--- a/rtos-docs/threadx/chapter4.adoc
+++ b/rtos-docs/threadx/chapter4.adoc
@@ -151,7 +151,7 @@ UINT tx_block_allocate(
 
 This service allocates a fixed-size memory block from the specified memory pool. The actual size of the memory block is determined during memory pool creation.
 
-IMPORTANT: _It is important to ensure application code does not write outside the allocated memory block. If this happens, corruption occurs in an adjacent (usually subsequent) memory block. The results are unpredictable and often fatal!_
+IMPORTANT: _It is important to ensure application code does not write outside the allocated memory block. If this happens, the behavior is undefined. Likewise, if the destination is not large enough, the behavior is undefined. That said, a typical consequence is memory corruption of an adjacent (usually subsequent) memory area. The results are unpredictable and often fatal!_
 
 === Parameters
 
@@ -671,7 +671,7 @@ UINT tx_byte_allocate(
 
 This service allocates the specified number of bytes from the specified memory byte pool.
 
-IMPORTANT: _It is important to ensure application code does not write outside the allocated memory block. If this happens, corruption occurs in an adjacent (usually subsequent) memory block. The results are unpredictable and often fatal!_
+IMPORTANT: _It is important to ensure application code does not write outside the allocated memory block. If this happens, the behavior is undefined. Likewise, if the destination is not large enough, the behavior is undefined. That said, a typical consequence is memory corruption of an adjacent (usually subsequent) memory area. The results are unpredictable and often fatal!_
 
 NOTE: _The performance of this service is a function of the block size and the amount of fragmentation in the pool. Hence, this service should not be used during time-critical threads of execution._
 
@@ -2819,7 +2819,7 @@ UINT tx_queue_receive(
 
 This service retrieves a message from the specified message queue. The retrieved message is *copied* from the queue into the memory area specified by the destination pointer. That message is then removed from the queue.
 
-IMPORTANT: _The specified destination memory area must be large enough to hold the message; i.e., the message destination pointed to by_ *_destination_ptr_* _must be at least as large as the message size for this queue. Otherwise, if the destination is not large enough, memory corruption occurs in the following memory area._
+IMPORTANT: _The specified destination memory area must be large enough to hold the message; i.e., the message destination pointed to by_ *_destination_ptr_* _must be at least as large as the message size for this queue. If the destination is not large enough, the behavior is undefined. That said, a typical consequence is memory corruption of an adjacent (usually subsequent) memory area._
 
 === Parameters
 


### PR DESCRIPTION
Implements the changes proposed in issue #8 to ensure the documentation is aligned with the C language standard.