### PR TITLE
Refactor GitHub Actions deployment to use Antora

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -40,7 +40,7 @@ jobs:
         run: npx antora antora-playbook.yml
       - name: push to rtos-docs-html
         run: |
-          cd "${{ github.workspace }}/html"
+          cd "${{ github.workspace }}/rtos-docs-html"
 
           git config user.name "eclipse-threadx-bot"
           git config user.email "<threadx-bot@eclipse.org>"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,37 +18,26 @@ jobs:
     if: github.repository == 'eclipse-threadx/rtos-docs-asciidoc'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
           path: 'asciidoc'
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout external HTML repository
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.TARGET_REPO }}
           ref: 'main'
-          path: 'html'
+          path: 'rtos-docs-html'
           token: ${{ secrets.DOCS_PUBLISH_TOKEN }}
-      - uses: ruby/setup-ruby@d781c1b4ed31764801bfae177617bb0446f5ef8d # v1.218.0
+      - name: Install Node.js
+        uses: actions/setup-node@v5
         with:
-          ruby-version: 3.4.1
-      - uses: reitzig/actions-asciidoctor@c642db5eedd1d729bb8c92034770d0b2f769eda6 # v2.0.2
-        with:
-          version: 2.0.23
-      - name: build html pages
-        run: |
-          DESTINATION="${{ github.workspace }}/html"
-          cd asciidoc/rtos-docs
-          for directory in `ls -d */`; do
-             if [ "${directory}" != "media/" ]; then
-              echo "${directory}"
-              CURRENT_DESTINATION=${DESTINATION}/${directory}
-              mkdir -p ${CURRENT_DESTINATION}
-              (cd "${directory}" && asciidoctor *.adoc --destination-dir=${CURRENT_DESTINATION})
-              if [ -d "${directory}/media" ]; then
-                (cd "${directory}" && cp -R media ${CURRENT_DESTINATION})
-              fi
-             fi
-          done
+          node-version: '18'
+      - name: Install Antora
+        run: npm i antora
+      - name: Generate Site
+        run: npx antora antora-playbook.yml
       - name: push to rtos-docs-html
         run: |
           cd "${{ github.workspace }}/html"


### PR DESCRIPTION
Updated workflow to use actions/checkout@v5 and actions/setup-node@v5. Removed Ruby setup and replaced build steps with Antora installation and site generation.

Based on the examples from https://docs.antora.org/antora/latest/publish-to-github-pages/#using-github-actions