### PR TITLE
Add workflow_dispatch trigger to build-and-publish

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - '*'
       - '!main'
+  workflow_dispatch:
 
 concurrency:
   group: run-${{ github.workflow }}-${{ github.ref }}
@@ -15,7 +16,9 @@ env:
 
 jobs:
   build:
-    if: github.repository == 'eclipse-threadx/rtos-docs-asciidoc'
+    if: >
+      github.repository == 'eclipse-threadx/rtos-docs-asciidoc' &&
+      github.ref_name != 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` trigger to the build-and-publish workflow so it can be run manually from the Actions UI and via `gh workflow run --ref <branch>` (e.g. to rebuild/publish release branches like `6.5.0`, `6.5.1`).
- Extends the job guard to also exclude `main` (`github.ref_name != 'main'`), so a manual dispatch that selects `main` is a no-op and never publishes `main` content to `rtos-docs-html`.

## Why
`gh workflow run` currently returns HTTP 422 ("Workflow does not have 'workflow_dispatch' trigger") and the Actions page shows no "Run workflow" button, because the workflow is push-only. Release branches that failed a prior run (e.g. a transient credential issue) can't be re-triggered once the original run is >1 month old. This adds a first-class manual trigger.

## Notes
- The existing `push` behavior is unchanged: pushes to any non-`main` branch still build/publish.
- `workflow_dispatch` is not subject to the `push` branch filter, hence the explicit `main` guard on the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)