### PR TITLE
Fix publish push to rtos-docs-html (no upstream branch)

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -55,4 +55,4 @@ jobs:
           COMMIT_MESSAGE="Publish generated html pages from ${{ github.repository }}/${{ github.ref }}@${{ github.sha }}"
           git add .
           git commit -m "${COMMIT_MESSAGE}"
-          git push origin
+          git push origin HEAD:${{ github.ref_name }}


### PR DESCRIPTION
## Summary
Fixes the `push to rtos-docs-html` step, which aborts with exit code 128 on every real run:

```
git checkout -B 6.5.0
Switched to a new branch '6.5.0'
fatal: The current branch 6.5.0 has no upstream branch.
```

After `git checkout -B <branch>` creates a fresh local branch with no upstream tracking, the bare `git push origin` (with the default `push.default=simple`) has no destination and fails. This changes it to an explicit refspec:

```diff
-          git push origin
+          git push origin HEAD:${{ github.ref_name }}
```

## Context
Surfaced when building/publishing the `6.5.0` and `6.5.1` release branches: Antora generated the site and the commit was created, but publishing failed at this step. The same fix has been applied directly to the `6.5.0` and `6.5.1` branches (their runs now publish successfully). This PR applies it to `main` so all future branch builds inherit the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)