### PR TITLE
Documented the Cortex-R52 port in hardware support

### DIFF
--- a/rtos-docs/home/modules/ROOT/pages/hardware-support.adoc
+++ b/rtos-docs/home/modules/ROOT/pages/hardware-support.adoc
@@ -42,10 +42,40 @@ The Cortex-M23, M33, M55 and M85 ports implement the ARMv8-M architecture, inclu
 |===
 | Core | Toolchains
 
-| Cortex-R4 | AC5, AC6, GHS, GNU, IAR
-| Cortex-R5 | AC5, AC6, GHS, GNU, IAR
-| Cortex-R7 | GHS
+| Cortex-R4  | AC5, AC6, GHS, GNU, IAR
+| Cortex-R5  | AC5, AC6, GHS, GNU, IAR
+| Cortex-R7  | GHS
+| Cortex-R52 | GNU
 |===
+
+The Cortex-R4, R5 and R7 ports implement the ARMv7-R architecture. The
+Cortex-R52 port implements ARMv8-R in AArch32 state and differs from them in
+ways that matter when writing board support:
+
+* The processor always implements EL2 and resets into it. The port is
+  EL2-aware: the reset path configures EL2, installs both the EL2 and EL1
+  vector tables, and then drops to EL1 to run the kernel. Several registers
+  must be programmed while still at EL2, notably `CNTFRQ`,
+  `CNTHCTL.PL1PCTEN`/`PL1PCEN` for EL1 access to the physical timer, and
+  `ICC_HSRE` for EL1 access to the GICv3 CPU interface.
+* Exceptions routed to EL2 from EL1 or EL0 all arrive at the Hyp Trap Entry,
+  vector offset `0x14`, and are distinguished by decoding `HSR.EC`.
+  Offsets `0x04`–`0x10` are exceptions taken from Hyp mode itself.
+* Memory protection is PMSAv8-R, programmed through `PRSELR`, `PRBAR` and
+  `PRLAR` with memory types supplied by `MAIR`. This replaces the PMSAv7
+  region model used by the ARMv7-R ports.
+* Interrupts are handled by a GICv3, whose CPU interface is reached through
+  `ICC_*` system registers rather than memory-mapped registers.
+* Floating point is FPv5 with double precision. As on the other ARM ports,
+  context is saved lazily for threads that call `tx_thread_vfp_enable()`;
+  note that enabling the FPU hardware itself (`CPACR`, `FPEXC.EN`) is the
+  board support package's responsibility, not the kernel's.
+
+The port is built with CMake and Ninja and ships an example build for the
+freely available ARMv8-R AEM Fixed Virtual Platform, which is sufficient to
+run the standard demonstration and the port's own self-tests without
+hardware. See `ports/cortex_r52/gnu/readme_threadx.txt` for build options and
+board-support detail.
 
 == ARM Cortex-A (single-core)
 


### PR DESCRIPTION
## Summary

Documents the new **Cortex-R52** port on the hardware support page: adds it to the Cortex-R table with the GNU toolchain, and explains how it differs from the ARMv7-R ports already listed.

Companion to the port itself (`eclipse-threadx/threadx`).

## What it says

The differences described are the ones that actually affect board support, rather than a restatement of the architecture:

* The processor always implements EL2 and resets into it, so the port is EL2-aware and several registers must be programmed before dropping to EL1 — `CNTFRQ`, `CNTHCTL.PL1PCTEN`/`PL1PCEN` for EL1 access to the physical timer, and `ICC_HSRE` for EL1 access to the GICv3 CPU interface.
* Exceptions routed to EL2 from EL1 or EL0 all arrive at the Hyp Trap Entry at vector offset `0x14` and are distinguished by decoding `HSR.EC`; offsets `0x04`–`0x10` are exceptions taken from Hyp mode itself.
* Memory protection is PMSAv8-R (`PRSELR`, `PRBAR`, `PRLAR`, `MAIR`), replacing the PMSAv7 region model of the ARMv7-R ports.
* Interrupts come from a GICv3 whose CPU interface is reached through `ICC_*` system registers rather than memory-mapped registers.
* Floating point is FPv5 with double precision. Context is saved lazily for threads that call `tx_thread_vfp_enable()`, but enabling the FPU hardware (`CPACR`, `FPEXC.EN`) is the board support package's responsibility, not the kernel's — worth stating because the naming suggests otherwise.

It also notes that the port builds with CMake and Ninja and ships an example build for the freely available ARMv8-R AEM Fixed Virtual Platform, so the standard demonstration and the port's self-tests can be run without hardware, and points readers at the port readme for build options.

## Scope

One file, one table row plus a short explanatory section. No structural or navigation changes. Rendering was checked by inspection — table delimiters balanced, list and code formatting consistent with the surrounding page — as no `asciidoctor` was available in this environment.
