### PR TITLE
Clarified when a service is callable during Initialization

### DIFF
--- a/rtos-docs/threadx/modules/ROOT/pages/chapter3.adoc
+++ b/rtos-docs/threadx/modules/ROOT/pages/chapter3.adoc
@@ -29,6 +29,8 @@ Figure 2 shows each different type of program execution. More detailed informati
 
 As the name implies, this is the first type of program execution in a ThreadX application. Initialization includes all program execution between processor reset and the entry point of the _thread scheduling loop._
 
+NOTE: _This describes the span of execution named Initialization, not the span in which ThreadX services may be called. A service listed as allowed from Initialization in_ xref:chapter4.adoc[Chapter 4 - Description of ThreadX Services] _may be called from_ *_tx_application_define_* _onward. See "Calling ThreadX Services During Initialization" later in this chapter._
+
 === Thread Execution
 
 After initialization is complete, ThreadX enters its thread scheduling loop. The scheduling loop looks for an application thread ready for execution. When a ready thread is found, ThreadX transfers control to it. After the thread is finished (or another higher-priority thread becomes ready), execution transfers back to the thread scheduling loop to find the next highest priority ready thread.
@@ -101,6 +103,8 @@ When the development tool initialization is complete, control transfers to the u
 
 IMPORTANT: _The call to tx_kernel_enter does not return, so do not place any processing after it._
 
+Preliminary processing performed in _main_ runs before the kernel exists, so it may set up hardware but it may not call ThreadX services. The same holds for the C++ global and static constructors that the development tool runs before _main_. See "Calling ThreadX Services During Initialization" below.
+
 === tx_kernel_enter
 
 The entry function coordinates initialization of various internal ThreadX data structures and then calls the application's definition function *_tx_application_define_*.
@@ -114,6 +118,19 @@ The *_tx_application_define_* function defines all of the initial application th
 The *_tx_application_define_* function has a single input parameter and it is certainly worth mentioning. The _first-available_ RAM address is the sole input parameter to this function. It is typically used as a starting point for initial run-time memory allocations of thread stacks, queues, and memory pools.
 
 NOTE: _After initialization is complete, only an executing thread can create and delete system resources-- including other threads. Therefore, at least one thread must be created during initialization._
+
+=== Calling ThreadX Services During Initialization
+
+Initialization spans everything between reset and the scheduler, but ThreadX services are not available across all of it. *_tx_kernel_enter_* sets up the kernel's internal data structures -- among them the created lists for threads, timers, queues, semaphores, mutexes and memory pools, and the list of active timers -- and only then calls *_tx_application_define_*. This is why a service listed as allowed from Initialization in xref:chapter4.adoc[Chapter 4 - Description of ThreadX Services] means allowed from *_tx_application_define_* onward.
+
+Code that runs earlier is still within Initialization as defined at the start of this chapter, but the kernel structures it needs do not exist yet. Calling a ThreadX service from there has one of two outcomes, neither of them useful:
+
+* *The application faults.* The service reaches a pointer into a kernel structure that has not been set up, and dereferences it. *_tx_timer_activate_* behaves this way, as does *_tx_timer_create_* when *TX_AUTO_ACTIVATE* is specified, because both place the timer on the list of active timers.
+* *The call appears to succeed and is then silently undone.* Creation services are the common case. The object is linked onto the created list for its type, and *_tx_kernel_enter_* subsequently resets that list, so ThreadX no longer knows about the object even though the application still holds a control block that looks valid.
+
+IMPORTANT: _Do not call a ThreadX service before_ *_tx_kernel_enter_*. _Neither outcome above is reported to the application: the first is a crash rather than an error code, and the second returns_ *TX_SUCCESS*.
+
+Some ports do initialize the kernel before _main_ is reached, because the development tool needs ThreadX services that early. The Green Hills ports are the example in the distribution: the tool's library-locking hook runs before the static constructors do, and it initializes the kernel so that it can create the mutex that guards those locks. Where a port does this, *_tx_kernel_enter_* detects that the work is already done and does not repeat it, and the two outcomes above do not arise. Whether a port pre-initializes the kernel is a property of that port rather than of the API, so portable application code must not depend on it.
 
 === Interrupts
 

--- a/rtos-docs/threadx/modules/ROOT/pages/chapter4.adoc
+++ b/rtos-docs/threadx/modules/ROOT/pages/chapter4.adoc
@@ -19,6 +19,8 @@
 
 This chapter contains a description of all ThreadX services in alphabetic order. Their names are designed so all similar services are grouped together. In the *Return Values* section in the following descriptions, values in *BOLD* are not affected by the *TX_DISABLE_ERROR_CHECKING* define used to disable API error checking; while values shown in nonbold are completely disabled. In addition, a "*Yes*" listed under the "*Preemption Possible*" heading indicates that calling the service may resume a higher-priority thread, thus preempting the calling thread.
 
+Under the *Allowed From* heading, "Initialization" means from *_tx_application_define_* onward. It does not extend to code that runs before *_tx_kernel_enter_*, such as C++ static constructors or preliminary processing in _main_, because the kernel structures these services operate on are set up by *_tx_kernel_enter_* itself. See "Calling ThreadX Services During Initialization" in xref:chapter3.adoc[Chapter 3 - Functional Components of ThreadX].
+
 The Threadx API functions available to the application are as follows.
 
 == Block_Pool_Services
@@ -4937,6 +4939,8 @@ This service activates the specified application timer. The expiration routines 
 
 NOTE: _An expired one-shot timer must be reset via_ *_tx_timer_change_* _before it can be activated again._
 
+IMPORTANT: _This service places the timer on the list of active timers, which_ *_tx_kernel_enter_* _sets up. Calling it before_ *_tx_kernel_enter_* _faults rather than returning an error._
+
 === Parameters
 
 * _timer_ptr_: Pointer to a previously created application timer.
@@ -5077,6 +5081,8 @@ periodic.
 NOTE: _After a one-shot timer expires, it must be reset via   tx_timer_change before it can be activated again._
 
 * _auto_activate_: Determines if the timer is automatically activated during creation. If this value is *TX_AUTO_ACTIVATE* (0x01) the timer is made active. Otherwise, if the value *TX_NO_ACTIVATE* (0x00) is selected, the timer is created in a non-active state. In this case, a subsequent *_tx_timer_activate_* service call is necessary to get the timer actually started.
++
+IMPORTANT: _*TX_AUTO_ACTIVATE* places the timer on the list of active timers, which_ *_tx_kernel_enter_* _sets up. Calling this service with *TX_AUTO_ACTIVATE* before_ *_tx_kernel_enter_* _faults rather than returning an error._
 
 === Return Values
 

--- a/rtos-docs/threadx/modules/ROOT/pages/threadx-smp/chapter3.adoc
+++ b/rtos-docs/threadx/modules/ROOT/pages/threadx-smp/chapter3.adoc
@@ -31,6 +31,8 @@ As the name implies, this is the first type of program execution in a ThreadX SM
 
 IMPORTANT: Initialization is performed by or initiated by core 0, which is the default running core after reset.
 
+NOTE: This describes the span of execution named Initialization, not the span in which ThreadX SMP services may be called. A service listed as allowed from Initialization in xref:threadx:ROOT:threadx-smp/chapter4.adoc[Chapter 4 - Description of ThreadX SMP Services] may be called from _tx_application_define_ onward. See "Calling ThreadX SMP Services During Initialization" later in this chapter.
+
 === Thread Execution
 
 After initialization is complete, each core running ThreadX SMP enters its thread scheduling loop. The scheduling loop looks for an application thread ready for execution on that core. When a ready thread is found, ThreadX SMP transfers control to it. After the thread is finished (or another higher-priority thread becomes ready), execution transfers back to the thread scheduling loop to find the next highest priority ready thread on each core.
@@ -107,6 +109,8 @@ When the development tool initialization is complete, control transfers to the u
 
 IMPORTANT: The call to tx_kernel_enter does not return, so do not place any processing after it!
 
+Preliminary processing performed in _main_ runs before the kernel exists, so it may set up hardware but it may not call ThreadX SMP services. The same holds for the C++ global and static constructors that the development tool runs before _main_. See "Calling ThreadX SMP Services During Initialization" below.
+
 === tx_kernel_enter
 
 The entry function coordinates initialization of various internal ThreadX SMP data structures and then calls the application's definition function _tx_application_define_.
@@ -120,6 +124,19 @@ The _tx_application_define_ function defines all of the initial application thre
 The _tx_application_define_ function has a single input parameter and it is certainly worth mentioning. The _first-available_ RAM address is the sole input parameter to this function. It is typically used as a starting point for initial run-time memory allocations of thread stacks, queues, and memory pools.
 
 IMPORTANT: After initialization is complete, only an executing thread can create and delete system resources--including other threads. Therefore, at least one thread must be created during initialization.
+
+=== Calling ThreadX SMP Services During Initialization
+
+Initialization spans everything between reset and the scheduler, but ThreadX SMP services are not available across all of it. _tx_kernel_enter_ sets up the kernel's internal data structures--among them the created lists for threads, timers, queues, semaphores, mutexes and memory pools, and the list of active timers--and only then calls _tx_application_define_. This is why a service listed as allowed from Initialization in xref:threadx:ROOT:threadx-smp/chapter4.adoc[Chapter 4 - Description of ThreadX SMP Services] means allowed from _tx_application_define_ onward.
+
+Code that runs earlier is still within Initialization as defined at the start of this chapter, but the kernel structures it needs do not exist yet. Calling a ThreadX SMP service from there has one of two outcomes, neither of them useful:
+
+* *The application faults.* The service reaches a pointer into a kernel structure that has not been set up, and dereferences it. _tx_timer_activate_ behaves this way, as does _tx_timer_create_ when *TX_AUTO_ACTIVATE* is specified, because both place the timer on the list of active timers.
+* *The call appears to succeed and is then silently undone.* Creation services are the common case. The object is linked onto the created list for its type, and _tx_kernel_enter_ subsequently resets that list, so ThreadX SMP no longer knows about the object even though the application still holds a control block that looks valid.
+
+IMPORTANT: Do not call a ThreadX SMP service before _tx_kernel_enter_. Neither outcome above is reported to the application: the first is a crash rather than an error code, and the second returns *TX_SUCCESS*.
+
+Some ports do initialize the kernel before _main_ is reached, because the development tool needs ThreadX SMP services that early. The Green Hills ports are the example in the distribution: the tool's library-locking hook runs before the static constructors do, and it initializes the kernel so that it can create the mutex that guards those locks. Where a port does this, _tx_kernel_enter_ detects that the work is already done and does not repeat it, and the two outcomes above do not arise. Whether a port pre-initializes the kernel is a property of that port rather than of the API, so portable application code must not depend on it.
 
 === Interrupts
 

--- a/rtos-docs/threadx/modules/ROOT/pages/threadx-smp/chapter4.adoc
+++ b/rtos-docs/threadx/modules/ROOT/pages/threadx-smp/chapter4.adoc
@@ -19,6 +19,8 @@
 
 This chapter contains a description of all ThreadX SMP services in alphabetic order. Their names are designed so all similar services are grouped together. In the "Return Values" section in the following descriptions, values in *BOLD* are not affected by the *TX_DISABLE_ERROR_CHECKING* define used to disable API error checking; while values shown in nonbold are completely disabled. In addition, a "*Yes*" listed under the "*Preemption Possible*" heading indicates that calling the service may resume a higher-priority thread, thus preempting the calling thread.
 
+Under the *Allowed From* heading, "Initialization" means from _tx_application_define_ onward. It does not extend to code that runs before _tx_kernel_enter_, such as C++ static constructors or preliminary processing in _main_, because the kernel structures these services operate on are set up by _tx_kernel_enter_ itself. See "Calling ThreadX SMP Services During Initialization" in xref:threadx:ROOT:threadx-smp/chapter3.adoc[Chapter 3 - Functional Components of ThreadX SMP].
+
 The Threadx SMP API functions available to the application are as follows.
 
 == Thread_SMP_Services

--- a/rtos-docs/threadx/modules/ROOT/pages/user-guide-armv8m/chapter3.adoc
+++ b/rtos-docs/threadx/modules/ROOT/pages/user-guide-armv8m/chapter3.adoc
@@ -19,6 +19,8 @@
 
 This chapter contains a description of the ARMv8-M-specific ThreadX services in alphabetic order. Their names are designed so all similar services are grouped together. In the "Return Values" section in the following descriptions, values in *BOLD* are not affected by the *TX_DISABLE_ERROR_CHECKING* define used to disable API error checking; while values shown in non-bold are completely disabled.
 
+Under the *Allowed From* heading, "Initialization" means from *_tx_application_define_* onward. It does not extend to code that runs before *_tx_kernel_enter_*, such as C++ static constructors or preliminary processing in _main_. See "Calling ThreadX Services During Initialization" in xref:threadx:ROOT:chapter3.adoc[Chapter 3 - Functional Components of ThreadX].
+
 * <<tx_thread_secure_stack_allocate,tx_thread_secure_stack_allocate>> Allocate a thread stack in secure memory.
 * <<tx_thread_secure_stack_free,tx_thread_secure_stack_free>> Free thread stack in secure memory
 


### PR DESCRIPTION
Addresses the ThreadX part of #27.

## The problem

Chapter 3 defines Initialization as "all program execution between processor reset and the entry point of the _thread scheduling loop_". Chapter 4 then lists 63 services as **Allowed From: Initialization**. Read together, those two statements promise that the services are callable anywhere in that window — including from C++ global and static constructors, or from `main` before `tx_kernel_enter`.

They are not. `tx_kernel_enter` is what sets up the kernel structures those services operate on, and it calls `tx_application_define` only once that work is done.

## What actually happens before `tx_kernel_enter`

Two failure modes, and neither is reported to the application:

- **A fault.** `_tx_timer_system_activate` computes `TX_TIMER_POINTER_ADD(_tx_timer_current_ptr, expiration_time)` and stores through the result. `_tx_timer_current_ptr` is only assigned by `_tx_timer_initialize`, so before that the arithmetic is done on `NULL`. This is what @acozz reported, and it covers `tx_timer_activate` and `tx_timer_create` with `TX_AUTO_ACTIVATE`.
- **A silently undone create.** A creation service links the object onto the created list for its type and returns `TX_SUCCESS`. `tx_kernel_enter` then runs each component's `_initialize`, which resets that list — `_tx_thread_initialize` does `_tx_thread_created_ptr = TX_NULL; _tx_thread_created_count = TX_EMPTY;`. The object is gone, but the application still holds a control block that looks valid. This is the more likely explanation for @acozz's observation that other services appeared to work when called during global initialization.

## One real exception, which the guide now records

The Green Hills ports (14 of them) call `_tx_initialize_kernel_setup` from the tool's `__gh_lock_init` hook, then `tx_mutex_create`, so that the library locks work during static construction. That leaves the system state at `TX_INITIALIZE_ALMOST_DONE`, which `tx_kernel_enter` detects and does not repeat. On those ports calls before `main` genuinely are safe — but that is a property of the port, not of the API, so the guide says portable code must not depend on it.

## The changes

The per-service **Allowed From** lines are correct once the term is defined properly, so this fixes the definition rather than editing 63 entries.

- `chapter3.adoc` — kept the definition of the execution type, added a note pointing at the real rule, said plainly that preliminary processing in `main` may not call ThreadX services, and added a "Calling ThreadX Services During Initialization" subsection covering the mechanism, both failure modes and the port exception.
- `chapter4.adoc` — pinned what "Initialization" means under the **Allowed From** heading, alongside the existing explanations of **Return Values** and **Preemption Possible**, so a reader landing directly on a service page gets it. Added warnings to `tx_timer_activate` and to `tx_timer_create`'s `auto_activate` parameter, since those fault rather than fail.
- `threadx-smp/chapter3.adoc`, `threadx-smp/chapter4.adoc` — the same treatment; the SMP guide carries the definition verbatim.
- `user-guide-armv8m/chapter3.adoc` — pinned the term in the preamble.

The other manuals in the suite use "Initialization" in their own **Allowed From** lines without defining it, so they inherit this definition. NetX Duo, GuiX and FileX already equate the initialization context with `tx_application_define` in prose, just far from their API tables. Follow-up PRs will reconcile those; FileX needs a real warning of its own, because `fx_system_initialize` calls `tx_timer_create` with `TX_AUTO_ACTIVATE` and so faults for exactly the reason above.

Antora builds clean with no warnings.