### PR TITLE
Titled each manual "<Component> User Guide"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ under `<component>/main/_exports/index.pdf`.
 ### Copy PDFs to a directory
 
 To collect all PDFs into a single directory with descriptive filenames
-(e.g. `eclipse-threadx-threadx-a4.pdf`):
+(e.g. `eclipse-threadx-threadx-user-guide-a4.pdf`):
 
 ```
 node scripts/copy-pdfs.js --output /path/to/output/dir

--- a/rtos-docs/filex/antora.yml
+++ b/rtos-docs/filex/antora.yml
@@ -1,5 +1,5 @@
 name: filex
-title: FileX
+title: FileX User Guide
 version: main
 start_page: index.adoc
 nav:

--- a/rtos-docs/filex/modules/ROOT/pages/index.adoc
+++ b/rtos-docs/filex/modules/ROOT/pages/index.adoc
@@ -14,7 +14,7 @@
 
 ////
 
-= FileX documentation
+= FileX User Guide
 
 xref:overview-filex.adoc[Overview of FileX]
 

--- a/rtos-docs/guix/antora.yml
+++ b/rtos-docs/guix/antora.yml
@@ -1,5 +1,5 @@
 name: guix
-title: GUIX
+title: GUIX User Guide
 version: main
 start_page: index.adoc
 nav:

--- a/rtos-docs/guix/modules/ROOT/pages/index.adoc
+++ b/rtos-docs/guix/modules/ROOT/pages/index.adoc
@@ -14,7 +14,7 @@
 
 ////
 
-= GUIX documentation
+= GUIX User Guide
 
 xref:overview-guix.adoc[Overview of GUIX]
 

--- a/rtos-docs/levelx/antora.yml
+++ b/rtos-docs/levelx/antora.yml
@@ -1,5 +1,5 @@
 name: levelx
-title: LevelX
+title: LevelX User Guide
 version: main
 start_page: index.adoc
 nav:

--- a/rtos-docs/levelx/modules/ROOT/pages/index.adoc
+++ b/rtos-docs/levelx/modules/ROOT/pages/index.adoc
@@ -14,7 +14,7 @@
 
 ////
 
-= LevelX documentation
+= LevelX User Guide
 
 LevelX user guide
 

--- a/rtos-docs/netx-duo/antora.yml
+++ b/rtos-docs/netx-duo/antora.yml
@@ -1,5 +1,5 @@
 name: netx-duo
-title: NetX Duo
+title: NetX Duo User Guide
 version: main
 start_page: index.adoc
 nav:

--- a/rtos-docs/netx-duo/modules/ROOT/pages/index.adoc
+++ b/rtos-docs/netx-duo/modules/ROOT/pages/index.adoc
@@ -14,7 +14,7 @@
 
 ////
 
-= NetX Duo documentation
+= NetX Duo User Guide
 
 xref:overview-netx-duo.adoc[Overview of NetX Duo]
 

--- a/rtos-docs/samplex/antora.yml
+++ b/rtos-docs/samplex/antora.yml
@@ -1,5 +1,5 @@
 name: samplex
-title: SampleX
+title: SampleX User Guide
 version: main
 start_page: index.adoc
 nav:

--- a/rtos-docs/samplex/modules/ROOT/pages/index.adoc
+++ b/rtos-docs/samplex/modules/ROOT/pages/index.adoc
@@ -13,7 +13,7 @@
 
 ////
 
-= SampleX documentation
+= SampleX User Guide
 :description: Board support package framework and sample applications for Eclipse ThreadX.
 
 SampleX hosts sample applications for Eclipse ThreadX together with the board support package (BSP) framework they are built on. The framework defines a small set of C interfaces that a board implements and an application consumes, so that one application source file can be built for boards of different architectures without being changed.

--- a/rtos-docs/threadx-modules/antora.yml
+++ b/rtos-docs/threadx-modules/antora.yml
@@ -1,5 +1,5 @@
 name: threadx-modules
-title: ThreadX Modules
+title: ThreadX Modules User Guide
 version: main
 start_page: index.adoc
 nav:

--- a/rtos-docs/threadx-modules/modules/ROOT/pages/index.adoc
+++ b/rtos-docs/threadx-modules/modules/ROOT/pages/index.adoc
@@ -14,7 +14,7 @@
 
 ////
 
-= ThreadX Modules documentation
+= ThreadX Modules User Guide
 
 ThreadX Modules user guide
 

--- a/rtos-docs/threadx/antora.yml
+++ b/rtos-docs/threadx/antora.yml
@@ -1,5 +1,5 @@
 name: threadx
-title: ThreadX
+title: ThreadX User Guide
 version: main
 start_page: index.adoc
 nav:

--- a/rtos-docs/threadx/modules/ROOT/pages/index.adoc
+++ b/rtos-docs/threadx/modules/ROOT/pages/index.adoc
@@ -14,7 +14,7 @@
 
 ////
 
-= ThreadX documentation
+= ThreadX User Guide
 
 xref:overview-threadx.adoc[Overview of ThreadX]
 

--- a/rtos-docs/tracex/antora.yml
+++ b/rtos-docs/tracex/antora.yml
@@ -1,5 +1,5 @@
 name: tracex
-title: TraceX
+title: TraceX User Guide
 version: main
 start_page: index.adoc
 nav:

--- a/rtos-docs/tracex/modules/ROOT/pages/index.adoc
+++ b/rtos-docs/tracex/modules/ROOT/pages/index.adoc
@@ -14,7 +14,7 @@
 
 ////
 
-= TraceX documentation
+= TraceX User Guide
 
 xref:overview-tracex.adoc[Overview of TraceX]
 

--- a/rtos-docs/usbx/antora.yml
+++ b/rtos-docs/usbx/antora.yml
@@ -1,5 +1,5 @@
 name: usbx
-title: USBX
+title: USBX User Guide
 version: main
 start_page: index.adoc
 nav:

--- a/rtos-docs/usbx/modules/ROOT/pages/index.adoc
+++ b/rtos-docs/usbx/modules/ROOT/pages/index.adoc
@@ -14,7 +14,7 @@
 
 ////
 
-= USBX documentation
+= USBX User Guide
 
 xref:overview-usbx.adoc[Overview of USBX]
 

--- a/rtos-docs/zonex/antora.yml
+++ b/rtos-docs/zonex/antora.yml
@@ -1,5 +1,5 @@
 name: zonex
-title: ZoneX
+title: ZoneX User Guide
 version: main
 start_page: index.adoc
 nav:

--- a/rtos-docs/zonex/modules/ROOT/pages/index.adoc
+++ b/rtos-docs/zonex/modules/ROOT/pages/index.adoc
@@ -13,7 +13,7 @@
 
 ////
 
-= ZoneX documentation
+= ZoneX User Guide
 :description: Deterministic partitioning hypervisor for Armv8-R, for mixed-criticality Eclipse ThreadX systems.
 
 ZoneX is a deterministic partitioning hypervisor for mixed-criticality embedded systems. It runs at EL2 on Armv8-R, gives each partition a statically declared slice of memory and of time, and treats a partition stepping outside either as a fault to be reported rather than a condition to be recovered from.

--- a/scripts/copy-pdfs.js
+++ b/scripts/copy-pdfs.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Copies generated PDFs from the build directory to a configurable output directory,
-// renaming them from index.pdf to eclipse-threadx-<component>-<size>.pdf.
+// renaming them from index.pdf to eclipse-threadx-<component>-user-guide-<size>.pdf.
 //
 // Usage:
 //   PDF_OUTPUT_DIR=/path/to/dir  node scripts/copy-pdfs.js
@@ -42,7 +42,7 @@ for (const size of fs.readdirSync(assemblerDir)) {
     const src = path.join(sizeDir, component, 'main', '_exports', 'index.pdf');
     if (!fs.existsSync(src)) continue;
 
-    const destName = `eclipse-threadx-${component}-${size}.pdf`;
+    const destName = `eclipse-threadx-${component}-user-guide-${size}.pdf`;
     fs.copyFileSync(src, path.join(dest, destName));
     console.log(`  ${destName}`);
     copied++;


### PR DESCRIPTION
The PDF covers read just `FileX`, `GUIX`, `ZoneX` and so on, which names the component rather than the document. Each manual is a user guide, so this says so.

## What changed

| Change | Files |
|---|---|
| `antora.yml` `title:` → `<Component> User Guide` | 10 |
| Landing heading `= <X> documentation` → `= <X> User Guide` | 10 |
| `copy-pdfs.js` filename + doc comment | 1 |
| `README.md` filename example | 1 |

The title comes from each component's `antora.yml`, so the same change also labels the component selector on the HTML site. The landing page headings followed so a reader arriving on the site sees the same name the PDF carries.

Collected PDFs are renamed from `eclipse-threadx-<component>-<size>.pdf` to `eclipse-threadx-<component>-user-guide-<size>.pdf`.

## What deliberately did not change

Product names stay put where they are product names rather than document titles — the component entries in the home navigation and resource list, and the prose describing each component, all still read `ThreadX`, `FileX` and so on. A navigation tree in which every entry ends in "User Guide" would be noise, and the prose is about the software rather than the book.

`home` is untouched, being a landing page rather than a manual and already excluded from the PDF builds.

## Verification

A full A4 and US Letter build of all ten components completes with an empty log, and all twenty covers carry the new title:

```
a4/filex             FileX User Guide             Version main, 2026-09-10
a4/netx-duo          NetX Duo User Guide          Version main, 2026-09-10
a4/threadx-modules   ThreadX Modules User Guide   Version main, 2026-09-10
a4/zonex             ZoneX User Guide             Version main, 2026-09-10
...
```

The longest, `ThreadX Modules User Guide`, still sets on one line inside the margins at the theme's 28pt. `copy-pdfs.js` was run to confirm all twenty new filenames.