### PR TITLE
Made the PDF workflow capable of running

### DIFF
--- a/.github/workflows/pdf-generate.yml
+++ b/.github/workflows/pdf-generate.yml
@@ -13,47 +13,73 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      # Publishing is skipped until the output repository exists and the token
+      # is configured. The build and the artifact upload still run, so this
+      # workflow can be dispatched to check the manuals before then.
+      HAS_PDF_TOKEN: ${{ secrets.PDF_REPO_TOKEN != '' }}
+
     steps:
       - name: Checkout documentation sources
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Checkout PDF output repository
-        uses: actions/checkout@v4
-        with:
-          repository: eclipse-threadx/rtos-docs-pdf
-          path: ../rtos-docs-pdf
-          token: ${{ secrets.PDF_REPO_TOKEN }}
+          path: 'asciidoc'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: 'asciidoc/package-lock.json'
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
+          working-directory: 'asciidoc'
 
       - name: Install Node.js dependencies
-        # The @antora/pdf-extension requires Antora >= 3.2 (testing channel).
-        run: npm install @antora/cli@testing @antora/site-generator@testing @antora/pdf-extension
+        # package.json pins the Antora 3.2 alphas the pdf-extension needs.
+        run: npm ci
+        working-directory: 'asciidoc'
 
       - name: Generate PDF manuals (A4 and US Letter)
         run: npx antora --fetch antora-pdf-playbook.yml
+        working-directory: 'asciidoc'
 
-      - name: Copy PDFs to output repository
-        run: |
-          mkdir -p ../rtos-docs-pdf/a4
-          mkdir -p ../rtos-docs-pdf/letter
-          cp build/assembler/a4/*.pdf ../rtos-docs-pdf/a4/ 2>/dev/null || echo "No A4 PDFs found"
-          cp build/assembler/letter/*.pdf ../rtos-docs-pdf/letter/ 2>/dev/null || echo "No Letter PDFs found"
+      - name: Collect PDFs
+        # copy-pdfs.js walks build/assembler/<size>/<component>/main/_exports/
+        # and gives each file a descriptive name; it owns that convention, so
+        # this workflow does not restate it. It exits non-zero when it finds
+        # nothing, so a silent build failure fails the job here rather than
+        # publishing an empty commit.
+        run: node scripts/copy-pdfs.js --output "${{ github.workspace }}/pdf-out"
+        working-directory: 'asciidoc'
+
+      - name: Upload PDFs as a workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: eclipse-threadx-manuals
+          path: pdf-out/*.pdf
+          if-no-files-found: error
+
+      - name: Checkout PDF output repository
+        if: env.HAS_PDF_TOKEN == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: eclipse-threadx/rtos-docs-pdf
+          path: 'rtos-docs-pdf'
+          token: ${{ secrets.PDF_REPO_TOKEN }}
+
+      - name: Copy PDFs into the output repository
+        if: env.HAS_PDF_TOKEN == 'true'
+        run: cp pdf-out/*.pdf rtos-docs-pdf/
 
       - name: Commit and push PDFs
-        working-directory: ../rtos-docs-pdf
+        if: env.HAS_PDF_TOKEN == 'true'
+        working-directory: 'rtos-docs-pdf'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -66,3 +92,9 @@ jobs:
           Generated from ${{ github.repository }}@${{ github.sha }}"
             git push
           fi
+
+      - name: Report skipped publish
+        if: env.HAS_PDF_TOKEN != 'true'
+        run: |
+          echo "PDF_REPO_TOKEN is not configured, so publishing was skipped." >> "$GITHUB_STEP_SUMMARY"
+          echo "The manuals are attached to this run as the 'eclipse-threadx-manuals' artifact." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The **Generate PDF Manuals** workflow could not have produced a PDF. Three separate faults, any one of which was enough.

## 1. The copy step could never match a file

```yaml
cp build/assembler/a4/*.pdf ../rtos-docs-pdf/a4/ 2>/dev/null || echo "No A4 PDFs found"
```

The assembler writes to `build/assembler/<size>/<component>/main/_exports/index.pdf`, so that pattern matches nothing. The mistake was invisible because `|| echo` turns the failure into a message and lets the step **exit 0** — a run would have reported success and pushed an empty commit.

## 2. The output checkout path was outside the workspace

`path: ../rtos-docs-pdf` is outside `GITHUB_WORKSPACE`, which `actions/checkout` refuses. The job would have failed on its second step, before building anything.

## 3. Ruby install would have failed too (already moot)

The `Gemfile` required `prawn-gmagick`, whose native extension needs GraphicsMagick headers this workflow never installed — the README listed them as a prerequisite precisely because they are not present by default. #66 dropped that dependency so this no longer applies, but it explains why the workflow was never noticed to be broken: it could not get far enough to reveal the copy bug.

## The fix

- Both repositories checked out to **named paths inside the workspace**, following the pattern `build-and-publish.yml` already uses, with `working-directory` on the build steps.
- Collection delegated to `scripts/copy-pdfs.js`, which already knows the assembler layout and owns the naming convention. It **exits non-zero when it finds no PDFs**, so a silent build failure now fails the job instead of publishing nothing.
- `npm ci` against the committed lockfile, rather than installing Antora by hand with `@testing` tags that bypass the pinned versions in `package.json`.

## Usable before the output repository exists

The manuals are uploaded as a run artifact, and the three publishing steps are gated on `PDF_REPO_TOKEN` being configured, with a run summary explaining the skip when it is not. **The workflow can therefore be dispatched today** to check the manuals — which is precisely what it could not do before.

## Verification

GitHub Actions cannot be run locally, so I mirrored the workflow's directory layout instead:

- Collection from the source subdirectory writes 20 PDFs to the workspace
- The artifact path `pdf-out/*.pdf` matches all 20 from the workspace root
- The copy into the output repository succeeds
- Both failure paths of the collection script — no build directory, and a build directory with no PDFs — exit non-zero, as the job now relies on

The YAML parses and the step conditions resolve as intended. A real `workflow_dispatch` run is still the only way to confirm the runner-side steps; with the token unset it will build, upload the artifact and report the skipped publish.

One thing to be aware of: the artifact is roughly 155 MB, since netx-duo and guix alone are 45 MB per page size.