### PR TITLE
Stop the PDF workflow depending on lockfiles it never has

### DIFF
--- a/.github/workflows/pdf-generate.yml
+++ b/.github/workflows/pdf-generate.yml
@@ -41,7 +41,7 @@ jobs:
           working-directory: 'asciidoc'
 
       - name: Install Node.js dependencies
-        # package.json pins the Antora 3.2 alphas the pdf-extension needs.
+        # Versions come from package.json; see the note above on lockfiles.
         run: npm install
         working-directory: 'asciidoc'
 

--- a/.github/workflows/pdf-generate.yml
+++ b/.github/workflows/pdf-generate.yml
@@ -26,23 +26,28 @@ jobs:
           fetch-depth: 0
           path: 'asciidoc'
 
+      # No dependency caching here, and no 'npm ci' or bundler-cache: this
+      # repository gitignores package-lock.json and Gemfile.lock, so there is
+      # no lockfile in a fresh checkout to cache against or install from.
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: 'asciidoc/package-lock.json'
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-          bundler-cache: true
           working-directory: 'asciidoc'
 
       - name: Install Node.js dependencies
         # package.json pins the Antora 3.2 alphas the pdf-extension needs.
-        run: npm ci
+        run: npm install
+        working-directory: 'asciidoc'
+
+      - name: Install Ruby dependencies
+        # Antora Assembler shells out to 'bundle exec asciidoctor-pdf'.
+        run: bundle install
         working-directory: 'asciidoc'
 
       - name: Generate PDF manuals (A4 and US Letter)


### PR DESCRIPTION
Follow-up to #69. The first dispatch of the repaired workflow ([run 34494491922](https://github.com/eclipse-threadx/rtos-docs-asciidoc/actions/runs/34494491922)) failed on its second step:

```
##[error]Some specified paths were not resolved, unable to cache dependencies.
```

This repository gitignores `package-lock.json` and `Gemfile.lock` (`.gitignore:6` and `:10`), so a fresh checkout contains neither. The `setup-node` cache had nothing to resolve, and `npm ci` — which cannot run without a lockfile — would have failed at the following step regardless.

The caching request predates #69; what was new was `npm ci`, which I added on the assumption that the lockfile it needs was committed. It is not, and my pre-merge check read the untracked one sitting in my own working tree.

## Fix

- Dropped `cache:` / `cache-dependency-path`, and `npm ci` → `npm install`.
- Removed `bundler-cache: true`, which was the identical trap one step further on and unreached only because `setup-node` failed first — `Gemfile.lock` is gitignored too. Ruby dependencies now install through an explicit `bundle install` step, so nothing in the job infers a lockfile that is not there.

Verified in a **clean clone**, which is what the runner gets:

```
npm ci       -> exit 1, npm error code EUSAGE
npm install  -> exit 0, @antora/cli 3.2.0 on the path
```

## A version drift this uncovered

The range in `package.json`, `^3.2.0-alpha.12`, now matches the stable release. A fresh install therefore resolves **Antora 3.2.0 and pdf-extension 1.0.0**, not the **3.2.0-alpha.12 and 1.0.0-beta.20** that a working tree populated earlier still holds. Every check behind #66 through #69 ran on the alpha pair, so none of them said anything about what CI would do.

Built all ten components on the stable pair to confirm the upgrade is invisible:

- Empty log, 20 PDFs, correct cover titles
- Page count identical to the alpha build in **all twenty** manuals (`a4/netx-duo` 2158, `letter/guix` 980, and so on)

So the stable resolve is safe, but it is worth knowing that local builds and CI builds are no longer on the same Antora until someone refreshes `node_modules`.