### PR TITLE
Ask for Antora's releases rather than its prereleases

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ If you want to propose changes or additions to the documentation, this is the ri
 
 ## Setup
 
-The project uses specific pre-release versions of Antora. Always use the locally
-installed toolchain rather than any globally installed `antora`.
+Always use the locally installed toolchain rather than any globally installed
+`antora`, so that the Antora version matches the one the PDF build is tested
+against.
 
 ### Prerequisites
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "copy:pdf": "node scripts/copy-pdfs.js"
   },
   "dependencies": {
-    "@antora/cli": "^3.2.0-alpha.12",
-    "@antora/pdf-extension": "^1.0.0-beta.20",
-    "@antora/site-generator": "^3.2.0-alpha.12"
+    "@antora/cli": "^3.2.0",
+    "@antora/pdf-extension": "^1.0.0",
+    "@antora/site-generator": "^3.2.0"
   }
 }


### PR DESCRIPTION
`package.json` requested `^3.2.0-alpha.12` for Antora and `^1.0.0-beta.20` for the PDF extension. Both features have since shipped — Antora 3.2.0 and pdf-extension 1.0.0 are released, and `npm outdated` reports the newest version satisfying each range as the stable one:

```
Package                        Current  Wanted  Latest
@antora/cli             3.2.0-alpha.12   3.2.0   3.2.0
@antora/pdf-extension    1.0.0-beta.20   1.0.0   1.0.0
@antora/site-generator  3.2.0-alpha.12   3.2.0   3.2.0
```

## Why change them, if they already admit the releases

A caret range does admit the release that follows the prerelease it names, so these were doing no harm. They were misleading in two ways though.

They read as though this project needs an unreleased Antora, which the README repeated in as many words.

More practically: because a prerelease sorts *below* its release, a `node_modules` that predates 3.2.0 keeps the alpha and correctly reports itself as satisfying `package.json` — so nothing ever prompts the upgrade. Local trees and fresh installs drift apart silently. That is exactly what happened during the recent PDF work: everything was verified against 3.2.0-alpha.12 while CI resolved 3.2.0, and the discrepancy only surfaced by accident.

## Change

- `^3.2.0-alpha.12` → `^3.2.0`, `^1.0.0-beta.20` → `^1.0.0`
- Dropped the README's claim that the toolchain is a prerelease, keeping its advice to prefer the local install over a global `antora`

## Verification

A fresh install against the new ranges resolves **the same versions this change was verified on** — Antora 3.2.0 and pdf-extension 1.0.0, with no alpha, beta or release candidate anywhere in the dependency tree. The ten components built and compared on that pair therefore still stand: empty log, correct cover titles, page counts identical to the alpha build in all twenty manuals.

## For anyone with an older checkout

```
npm update
```

Not `npm install` — I tested both, and `npm install` leaves a satisfying prerelease in place. Only `npm update` walks each dependency to the newest version the range allows.