### PR TITLE
Documented that the prioritize services act at a single point in time

### DIFF
--- a/rtos-docs/threadx/modules/ROOT/pages/chapter3.adoc
+++ b/rtos-docs/threadx/modules/ROOT/pages/chapter3.adoc
@@ -440,7 +440,7 @@ Application threads can suspend while attempting to send or receive a message fr
 
 After the condition for suspension is resolved, the service requested is completed and the waiting thread is resumed. If multiple threads are suspended on the same queue, they are resumed in the order they were suspended (FIFO).
 
-However, priority resumption is also possible if the application calls *_tx_queue_prioritize_* prior to the queue service that lifts thread suspension. The queue prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order.
+However, priority resumption is also possible if the application calls *_tx_queue_prioritize_* prior to the queue service that lifts thread suspension. The queue prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order. Note that the prioritize service acts at a single point in time: if an ISR or another thread suspends on or resumes from the same queue before the call that lifts suspension is made, the highest priority thread may no longer be at the front of the list. An application that needs the two calls to be atomic must protect them itself, either with *_tx_interrupt_control_* or, when only threads access the queue, with a mutex.
 
 Time-outs are also available for all queue suspensions. Basically, a time-out specifies the maximum number of timer ticks the thread will stay suspended. If a time-out occurs, the thread is resumed and the service returns with the appropriate error code.
 
@@ -525,7 +525,7 @@ Application threads can suspend while attempting to perform a get operation on a
 
 After a put operation is performed, the suspended thread's get operation is performed and the thread is resumed. If multiple threads are suspended on the same counting semaphore, they are resumed in the same order they were suspended (FIFO).
 
-However, priority resumption is also possible if the application calls *_tx_semaphore_prioritize_* prior to the semaphore put call that lifts thread suspension. The semaphore prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order.
+However, priority resumption is also possible if the application calls *_tx_semaphore_prioritize_* prior to the semaphore put call that lifts thread suspension. The semaphore prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order. Note that the prioritize service acts at a single point in time: if an ISR or another thread suspends on or resumes from the same semaphore before the call that lifts suspension is made, the highest priority thread may no longer be at the front of the list. An application that needs the two calls to be atomic must protect them itself, either with *_tx_interrupt_control_* or, when only threads access the semaphore, with a mutex.
 
 === Semaphore Put Notification
 
@@ -610,7 +610,7 @@ Application threads can suspend while attempting to perform a get operation on a
 
 After the same number of put operations are performed by the owning thread, the suspended thread's get operation is performed, giving it ownership of the mutex, and the thread is resumed. If multiple threads are suspended on the same mutex, they are resumed in the same order they were suspended (FIFO).
 
-However, priority resumption is done automatically if the mutex priority inheritance was selected during creation. Priority resumption is also possible if the application calls *_tx_mutex_prioritize_* prior to the mutex put call that lifts thread suspension. The mutex prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order.
+However, priority resumption is done automatically if the mutex priority inheritance was selected during creation. Priority resumption is also possible if the application calls *_tx_mutex_prioritize_* prior to the mutex put call that lifts thread suspension. The mutex prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order. Note that the prioritize service acts at a single point in time: if an ISR or another thread suspends on or resumes from the same mutex before the call that lifts suspension is made, the highest priority thread may no longer be at the front of the list. An application that needs the two calls to be atomic must protect them itself, either with *_tx_interrupt_control_* or, when only threads access the mutex, with a mutex.
 
 === Run-time Mutex Performance Information
 
@@ -756,7 +756,7 @@ Application threads can suspend while waiting for a memory block from an empty p
 
 If multiple threads are suspended on the same memory block pool, they are resumed in the order they were suspended (FIFO).
 
-However, priority resumption is also possible if the application calls *_tx_block_pool_prioritize_* prior to the block release call that lifts thread suspension. The block pool prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order.
+However, priority resumption is also possible if the application calls *_tx_block_pool_prioritize_* prior to the block release call that lifts thread suspension. The block pool prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order. Note that the prioritize service acts at a single point in time: if an ISR or another thread suspends on or resumes from the same pool before the call that lifts suspension is made, the highest priority thread may no longer be at the front of the list. An application that needs the two calls to be atomic must protect them itself, either with *_tx_interrupt_control_* or, when only threads access the pool, with a mutex.
 
 === Run-time Block Pool Performance Information
 
@@ -825,7 +825,7 @@ Application threads can suspend while waiting for memory bytes from a pool. When
 
 If multiple threads are suspended on the same memory byte pool, they are given memory (resumed) in the order they were suspended (FIFO).
 
-However, priority resumption is also possible if the application calls *_tx_byte_pool_prioritize_* prior to the byte release call that lifts thread suspension. The byte pool prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order.
+However, priority resumption is also possible if the application calls *_tx_byte_pool_prioritize_* prior to the byte release call that lifts thread suspension. The byte pool prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order. Note that the prioritize service acts at a single point in time: if an ISR or another thread suspends on or resumes from the same pool before the call that lifts suspension is made, the highest priority thread may no longer be at the front of the list. An application that needs the two calls to be atomic must protect them itself, either with *_tx_interrupt_control_* or, when only threads access the pool, with a mutex.
 
 === Run-time Byte Pool Performance Information
 

--- a/rtos-docs/threadx/modules/ROOT/pages/chapter4.adoc
+++ b/rtos-docs/threadx/modules/ROOT/pages/chapter4.adoc
@@ -560,6 +560,8 @@ UINT tx_block_pool_prioritize(TX_BLOCK_POOL *pool_ptr);
 
 This service places the highest priority thread suspended for a block of memory on this pool at the front of the suspension list. All other threads remain in the same FIFO order they were suspended in.
 
+NOTE: _This service acts at a single point in time. Any asynchronous activity that follows it, such as an ISR or another thread suspending on or resuming from the same pool, can reorder the suspension list again, so the highest priority thread is not guaranteed to still be at the front when the next tx_block_release call is made. A second call to this service made while the list is already prioritized has no further effect. An application that needs the prioritize call and the call that lifts suspension to be atomic must protect the pair itself, either with tx_interrupt_control or, when only threads access the pool, with a mutex._
+
 === Parameters
 
 * _pool_ptr_: Pointer to a memory block pool control block.
@@ -1094,6 +1096,8 @@ UINT tx_byte_pool_prioritize(TX_BYTE_POOL *pool_ptr);
 === Description
 
 This service places the highest priority thread suspended for memory on this pool at the front of the suspension list. All other threads remain in the same FIFO order they were suspended in.
+
+NOTE: _This service acts at a single point in time. Any asynchronous activity that follows it, such as an ISR or another thread suspending on or resuming from the same pool, can reorder the suspension list again, so the highest priority thread is not guaranteed to still be at the front when the next tx_byte_release call is made. A second call to this service made while the list is already prioritized has no further effect. An application that needs the prioritize call and the call that lifts suspension to be atomic must protect the pair itself, either with tx_interrupt_control or, when only threads access the pool, with a mutex._
 
 === Parameters
 
@@ -2181,6 +2185,8 @@ UINT tx_mutex_prioritize(TX_MUTEX *mutex_ptr);
 
 This service places the highest priority thread suspended for ownership of the mutex at the front of the suspension list. All other threads remain in the same FIFO order they were suspended in.
 
+NOTE: _This service acts at a single point in time. Any asynchronous activity that follows it, such as an ISR or another thread suspending on or resuming from the same mutex, can reorder the suspension list again, so the highest priority thread is not guaranteed to still be at the front when the next tx_mutex_put call is made. A second call to this service made while the list is already prioritized has no further effect. An application that needs the prioritize call and the call that lifts suspension to be atomic must protect the pair itself, either with tx_interrupt_control or, when only threads access the mutex, with a mutex._
+
 === Parameters
 
 * _mutex_ptr_: Pointer to the previously created mutex.
@@ -2764,6 +2770,8 @@ UINT tx_queue_prioritize(TX_QUEUE *queue_ptr);
 This service places the highest priority thread suspended for a message (or to place a message) on this queue at the front of the suspension list.
 
 All other threads remain in the same FIFO order they were suspended in.
+
+NOTE: _This service acts at a single point in time. Any asynchronous activity that follows it, such as an ISR or another thread suspending on or resuming from the same queue, can reorder the suspension list again, so the highest priority thread is not guaranteed to still be at the front when the next tx_queue_send or tx_queue_receive call is made. A second call to this service made while the list is already prioritized has no further effect. An application that needs the prioritize call and the call that lifts suspension to be atomic must protect the pair itself, either with tx_interrupt_control or, when only threads access the queue, with a mutex._
 
 === Parameters
 
@@ -3458,6 +3466,8 @@ UINT tx_semaphore_prioritize(TX_SEMAPHORE *semaphore_ptr);
 === Description
 
 This service places the highest priority thread suspended for an instance of the semaphore at the front of the suspension list. All other threads remain in the same FIFO order they were suspended in.
+
+NOTE: _This service acts at a single point in time. Any asynchronous activity that follows it, such as an ISR or another thread suspending on or resuming from the same semaphore, can reorder the suspension list again, so the highest priority thread is not guaranteed to still be at the front when the next tx_semaphore_put call is made. A second call to this service made while the list is already prioritized has no further effect. An application that needs the prioritize call and the call that lifts suspension to be atomic must protect the pair itself, either with tx_interrupt_control or, when only threads access the semaphore, with a mutex._
 
 === Parameters
 

--- a/rtos-docs/threadx/modules/ROOT/pages/threadx-smp/chapter3.adoc
+++ b/rtos-docs/threadx/modules/ROOT/pages/threadx-smp/chapter3.adoc
@@ -418,7 +418,7 @@ Application threads can suspend while attempting to send or receive a message fr
 
 After the condition for suspension is resolved, the service requested is completed and the waiting thread is resumed. If multiple threads are suspended on the same queue, they are resumed in the order they were suspended (FIFO).
 
-However, priority resumption is also possible if the application calls *_tx_queue_prioritize_* prior to the queue service that lifts thread suspension. The queue prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order.
+However, priority resumption is also possible if the application calls *_tx_queue_prioritize_* prior to the queue service that lifts thread suspension. The queue prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order. Note that the prioritize service acts at a single point in time: if an ISR or another thread suspends on or resumes from the same queue before the call that lifts suspension is made, the highest priority thread may no longer be at the front of the list. An application that needs the two calls to be atomic must protect them itself, either with *_tx_interrupt_control_* or, when only threads access the queue, with a mutex.
 
 Time-outs are also available for all queue suspensions. Basically, a time-out specifies the maximum number of timer ticks the thread will stay suspended. If a time-out occurs, the thread is resumed and the service returns with the appropriate error code.
 
@@ -498,7 +498,7 @@ Application threads can suspend while attempting to perform a get operation on a
 
 After a put operation is performed, the suspended thread's get operation is performed and the thread is resumed. If multiple threads are suspended on the same counting semaphore, they are resumed in the same order they were suspended (FIFO).
 
-However, priority resumption is also possible if the application calls *_tx_semaphore_prioritize_* prior to the semaphore put call that lifts thread suspension. The semaphore prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order.
+However, priority resumption is also possible if the application calls *_tx_semaphore_prioritize_* prior to the semaphore put call that lifts thread suspension. The semaphore prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order. Note that the prioritize service acts at a single point in time: if an ISR or another thread suspends on or resumes from the same semaphore before the call that lifts suspension is made, the highest priority thread may no longer be at the front of the list. An application that needs the two calls to be atomic must protect them itself, either with *_tx_interrupt_control_* or, when only threads access the semaphore, with a mutex.
 
 === Semaphore Put Notification
 
@@ -580,7 +580,7 @@ Application threads can suspend while attempting to perform a get operation on a
 
 After the same number of put operations are performed by the owning thread, the suspended thread's get operation is performed, giving it ownership of the mutex, and the thread is resumed. If multiple threads are suspended on the same mutex, they are resumed in the same order they were suspended (FIFO).
 
-However, priority resumption is done automatically if the mutex priority inheritance was selected during creation. Priority resumption is also possible if the application calls *_tx_mutex_prioritize_* prior to the mutex put call that lifts thread suspension. The mutex prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order.
+However, priority resumption is done automatically if the mutex priority inheritance was selected during creation. Priority resumption is also possible if the application calls *_tx_mutex_prioritize_* prior to the mutex put call that lifts thread suspension. The mutex prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order. Note that the prioritize service acts at a single point in time: if an ISR or another thread suspends on or resumes from the same mutex before the call that lifts suspension is made, the highest priority thread may no longer be at the front of the list. An application that needs the two calls to be atomic must protect them itself, either with *_tx_interrupt_control_* or, when only threads access the mutex, with a mutex.
 
 === Run-time Mutex Performance Information
 
@@ -720,7 +720,7 @@ Application threads can suspend while waiting for a memory block from an empty p
 
 If multiple threads are suspended on the same memory block pool, they are resumed in the order they were suspended (FIFO).
 
-However, priority resumption is also possible if the application calls *_tx_block_pool_prioritize_* prior to the block release call that lifts thread suspension. The block pool prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order.
+However, priority resumption is also possible if the application calls *_tx_block_pool_prioritize_* prior to the block release call that lifts thread suspension. The block pool prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order. Note that the prioritize service acts at a single point in time: if an ISR or another thread suspends on or resumes from the same pool before the call that lifts suspension is made, the highest priority thread may no longer be at the front of the list. An application that needs the two calls to be atomic must protect them itself, either with *_tx_interrupt_control_* or, when only threads access the pool, with a mutex.
 
 === Run-time Block Pool Performance Information
 
@@ -784,7 +784,7 @@ Application threads can suspend while waiting for memory bytes from a pool. When
 
 If multiple threads are suspended on the same memory byte pool, they are given memory (resumed) in the order they were suspended (FIFO).
 
-However, priority resumption is also possible if the application calls *_tx_byte_pool_prioritize_* prior to the byte release call that lifts thread suspension. The byte pool prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order.
+However, priority resumption is also possible if the application calls *_tx_byte_pool_prioritize_* prior to the byte release call that lifts thread suspension. The byte pool prioritize service places the highest priority thread at the front of the suspension list, while leaving all other suspended threads in the same FIFO order. Note that the prioritize service acts at a single point in time: if an ISR or another thread suspends on or resumes from the same pool before the call that lifts suspension is made, the highest priority thread may no longer be at the front of the list. An application that needs the two calls to be atomic must protect them itself, either with *_tx_interrupt_control_* or, when only threads access the pool, with a mutex.
 
 === Run-time Byte Pool Performance Information
 


### PR DESCRIPTION
The `tx_*_prioritize` services move the highest priority suspended thread to the front of an object's suspension list, and the documentation described that effect without saying how long it lasts. Read literally, it invites the conclusion that a prioritize call followed by a release call will always wake the highest priority thread, which is not what the services promise.

The effect is a snapshot. Between the prioritize call and the call that lifts suspension, an ISR or another thread can suspend on or resume from the same object, and the list is reordered again. A second prioritize call made while the list is already prioritized changes nothing, so pairing one in a thread with one in an ISR does not close the window either. Atomicity, where it is needed, has to come from the application, through `tx_interrupt_control` or, when only threads touch the object, through a mutex.

This adds a note to that effect to each of the five prioritize entries in the API reference of the ThreadX User Guide, naming the service that lifts suspension in each case, and extends the corresponding paragraphs in the functional component chapters of both the ThreadX and the ThreadX SMP guides, where the prioritize services are introduced.

The site builds cleanly with Antora 3.2.0 and the fifteen new passages render as expected, five as note admonitions in the API reference and ten inline.

Reported in eclipse-threadx/threadx#507.
