### PR TITLE
Documented that tx_timer_change may be called from initialization, matching the relaxed caller check in the kernel

### DIFF
--- a/rtos-docs/threadx/modules/ROOT/pages/chapter4.adoc
+++ b/rtos-docs/threadx/modules/ROOT/pages/chapter4.adoc
@@ -5022,11 +5022,10 @@ NOTE: _An expired one-shot timer must be reset via_
 * *TX_SUCCESS* (0x00) Successful application timer change.
 * *TX_TIMER_ERROR* (0x15) Invalid application timer pointer.
 * *TX_TICK_ERROR* (0x16) Invalid value (a zero) supplied for initial ticks.
-* *TX_CALLER_ERROR* (0x13) Invalid caller of this service.
 
 === Allowed From
 
-Threads, timers, and ISRs
+Initialization, threads, timers, and ISRs
 
 === Preemption Possible
 


### PR DESCRIPTION
The `tx_timer_change` entry in Chapter 4 listed *Threads, timers, and ISRs* under **Allowed From** and `TX_CALLER_ERROR` among the return values. Neither is accurate once the initialization caller check is removed from `_txe_timer_change` in eclipse-threadx/threadx#224, so this updates both to match.
